### PR TITLE
Add a `g:tidal-boot` option for selecting the Tidal ghci boot file

### DIFF
--- a/Tidal.ghci
+++ b/Tidal.ghci
@@ -40,6 +40,7 @@ let only = (hush >>)
     jumpIn i t = transition tidal True (Sound.Tidal.Transition.jumpIn t) i
     jumpIn' i t = transition tidal True (Sound.Tidal.Transition.jumpIn' t) i
     jumpMod i t = transition tidal True (Sound.Tidal.Transition.jumpMod t) i
+    jumpMod' i t p = transition tidal True (Sound.Tidal.Transition.jumpMod' t p) i
     mortal i lifespan release = transition tidal True (Sound.Tidal.Transition.mortal lifespan release) i
     interpolate i = transition tidal True (Sound.Tidal.Transition.interpolate) i
     interpolateIn i t = transition tidal True (Sound.Tidal.Transition.interpolateIn t) i
@@ -77,3 +78,5 @@ let getState = streamGet tidal
 
 :set prompt "tidal> "
 :set prompt-cont ""
+
+default (Pattern String, Integer, Double)

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -36,6 +36,10 @@ if !exists("g:tidal_ghci")
   let g:tidal_ghci = "ghci"
 endif
 
+if !exists("g:tidal_boot")
+  let g:tidal_boot = s:parent_path . "/Tidal.ghci"
+endif
+
 if filereadable(s:parent_path . "/.dirt-samples")
   let &l:dictionary .= ',' . s:parent_path . "/.dirt-samples"
 endif
@@ -105,9 +109,8 @@ function! s:TerminalOpen()
     :exe "normal \<c-w>10-"
 
   elseif has('terminal')
-    let startup = s:parent_path . "/Tidal.ghci"
     execute "below split"
-    let s:tidal_term = term_start((g:tidal_ghci . " -ghci-script=" . startup), #{
+    let s:tidal_term = term_start((g:tidal_ghci . " -ghci-script=" . g:tidal_boot), #{
           \ term_name: 'tidal',
           \ term_rows: 10,
           \ norestore: 1,


### PR DESCRIPTION
This allows a user to specify the target `BootTidal.hs` file via
vimscript. This is originally motivated by [tidalcycles.nix][1], as it
can be used to specify the instance of `BootTidal.hs` in the nix store
as the default tidal boot file.

[1]: https://github.com/mitchmindtree/tidalcycles.nix